### PR TITLE
add log poisonings

### DIFF
--- a/dnsvalidator/dnsvalidator.py
+++ b/dnsvalidator/dnsvalidator.py
@@ -65,8 +65,14 @@ def resolve_address(server):
 
             # nxdomain exception was not thrown, we got records when we shouldn't have.
             # Skip the server.
-            output.terminal(Level.ERROR, server,
-                            "DNS poisoning detected, passing")
+            if arguments.poisoningslog:
+                output.terminal(Level.ERROR, server,
+                                "DNS poisoning detected, logging target to "
+                                + arguments.poisoningslog)
+                output.log_poisonings(server)
+            else:
+                output.terminal(Level.ERROR, server,
+                                "DNS poisoning detected, passing")
             return
         except dns.resolver.NXDOMAIN:
             pass

--- a/dnsvalidator/lib/core/input.py
+++ b/dnsvalidator/lib/core/input.py
@@ -154,4 +154,8 @@ class InputParser(object):
                  'and other information will be redacted.'
         )
 
+        parser.add_argument(
+            '--log-poisonings', dest='poisoningslog',
+            help='Destination file to write detected poisoned DNS servers to. '
+        )
         return parser

--- a/dnsvalidator/lib/core/output.py
+++ b/dnsvalidator/lib/core/output.py
@@ -16,6 +16,7 @@ class OutputHelper(object):
         self.seperator = "======================================================="
         self.silent = arguments.silent
         self.output = arguments.output
+        self.poisoningslog = arguments.poisoningslog
 
     def print_banner(self):
         if self.silent:
@@ -65,6 +66,11 @@ class OutputHelper(object):
             f = open(self.output, 'a+')
             f.writelines("\n" + target)
             f.close()
+
+    def log_poisonings(self, target):
+        f = open(self.poisoningslog, 'a+')
+        f.writelines(target + "\n")
+        f.close()
 
 
 class Level(IntEnum):


### PR DESCRIPTION
to resolve issue: #14 
* new command line argument `--log-poisonings POISIONINGSLOG`
```
$ dnsvalidator -h
usage: dnsvalidator [-h] [-t TARGET | -tL TARGET_LIST]
                    [-e EXCLUSION | -eL EXCLUSIONS_LIST] [-o OUTPUT]
                    [-r ROOTDOMAIN] [-q QUERY] [-threads THREADS]
                    [-timeout TIMEOUT] [--no-color] [-v | --silent]
                    [--log-poisonings POISONINGSLOG]

optional arguments:
  -h, --help            show this help message and exit
  -t TARGET             Specify a target DNS server to try resolving.
  -tL TARGET_LIST       Specify a list of target DNS servers to try to
                        resolve. May be a file, or URL to listing
  -e EXCLUSION          Specify an exclusion to remove from any target lists.
  -eL EXCLUSIONS_LIST   Specify a list of exclusions to avoid resolving. May
                        be a file or URL to listing
  -o OUTPUT, --output OUTPUT
                        Destination file to write successful DNS validations
                        to.
  -r ROOTDOMAIN         Specify a root domain to compare to (default:
  -q QUERY              Specify a resolver query to use (default:dnsvalidator)
  -threads THREADS      Specify the maximum number of threads to run
                        (DEFAULT:5)
  -timeout TIMEOUT      Command timeout in seconds (DEFAULT:600)
  --no-color            If set then any foreground or background colours will
                        be stripped out.
  -v, --verbose         If set then verbose output will be displayed in the
                        terminal.
  --silent              If set only findings will be displayed and banners and
                        other information will be redacted.
  --log-poisonings POISONINGSLOG
                        Destination file to write detected poisoned DNS
                        servers to.
``` 
* with new argument
```
$ dnsvalidator --log-poisonings test.txt
=======================================================
dnsvalidator v0.1	by James McLean (@vortexau) 
                	& Michael Skelton (@codingo_)
=======================================================
[22:00:40] [INFO] [1.1.1.1] resolving baseline
[22:00:40] [INFO] [8.8.8.8] resolving baseline
[22:00:40] [INFO] [9.9.9.9] resolving baseline
[22:00:41] [INFO] [109.86.225.220] Checking...
...
[22:01:24] [ACCEPTED] [156.154.70.40] provided valid response
[22:01:24] [INFO] [208.93.4.81] Checking...
[22:01:24] [ERROR] [208.93.4.81] DNS poisoning detected, logging target to test.txt
[22:01:24] [INFO] [190.56.169.145] Checking...
```
```
$ cat test.txt 
208.93.4.81
```
* without new argument
```
$ dnsvalidator
=======================================================
dnsvalidator v0.1	by James McLean (@vortexau) 
                	& Michael Skelton (@codingo_)
=======================================================
[22:04:56] [INFO] [1.1.1.1] resolving baseline
[22:04:57] [INFO] [8.8.8.8] resolving baseline
[22:04:57] [INFO] [9.9.9.9] resolving baseline
[22:04:57] [INFO] [193.36.189.34] Checking...
...
22:07:17] [INFO] [89.216.29.90] Checking...
[22:07:18] [ACCEPTED] [210.57.211.36] provided valid response
[22:07:18] [INFO] [82.99.211.195] Checking...
[22:07:19] [ERROR] [82.99.211.195] DNS poisoning detected, passing
[22:07:19] [INFO] [148.240.167.69] Checking...
```



