### PR TITLE
Refine Package Discovery in Setup Script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as file:
         version=__version__,
         author_email="",
         url="https://github.com/vortexau/dnsvalidator",
-        packages=find_packages(exclude=('tests')),
+        packages=find_packages(include=['dnsvalidator', 'dnsvalidator.*']),
         package_data={'dnsvalidator': ['*.txt']},
         entry_points={
             'console_scripts': [


### PR DESCRIPTION
This commit addresses an issue with the package discovery process in the setup script. Previously, the `find_packages` function from `setuptools` was used with an exclusion filter for the 'tests' directory. However, this approach did not account for the specific structure of our project, potentially leading to some packages being overlooked or incorrectly included.

Changes made:
- Modified the `find_packages` call to explicitly include the main package 'dnsvalidator' and all its sub-packages. This ensures that the setup script correctly locates and includes all necessary packages within the 'dnsvalidator' directory, aligning with our project's directory structure.

This modification aims at enhancing the reliability and accuracy of the package setup process, ensuring a smoother installation and deployment experience for users and contributors.